### PR TITLE
Make `temporary_shared` and `freeze_album` optional

### DIFF
--- a/src/foto.rs
+++ b/src/foto.rs
@@ -41,15 +41,13 @@ pub mod browse {
                 pub owner_user_id: u32,
                 pub passphrase: String,
                 pub shared: bool,
-                #[serde(default)]
-                pub temporary_shared: bool,
+                pub temporary_shared: Option<bool>,
                 pub sort_by: String,
                 pub sort_direction: String,
                 pub create_time: u64,
                 pub start_time: u64,
                 pub end_time: u64,
-                #[serde(default)]
-                pub freeze_album: bool,
+                pub freeze_album: Option<bool>,
                 pub version: u32,
             }
         }

--- a/src/foto.rs
+++ b/src/foto.rs
@@ -41,12 +41,14 @@ pub mod browse {
                 pub owner_user_id: u32,
                 pub passphrase: String,
                 pub shared: bool,
+                #[serde(default)]
                 pub temporary_shared: bool,
                 pub sort_by: String,
                 pub sort_direction: String,
                 pub create_time: u64,
                 pub start_time: u64,
                 pub end_time: u64,
+                #[serde(default)]
                 pub freeze_album: bool,
                 pub version: u32,
             }


### PR DESCRIPTION
Running against my Synology Photos instance was resulting in the following error:

```txt
missing field `temporary_shared` at line 1 column 4366
```

Making it `false` should be an appropriate approach if it's missing, together with `freeze_album` (same story).

The alternative would be to make it `Optional`.